### PR TITLE
Leverage built in LED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ add_executable(picoprobe
         src/cdc_uart.c
 )
 
+if (DEFINED ENV{PICOPROBE_LED})
+        message("PICOPROBE_LED is defined as " $ENV{PICOPROBE_LED})
+        target_compile_definitions(picoprobe PRIVATE PICOPROBE_LED=$ENV{PICOPROBE_LED})
+endif()
+
 set(DBG_PIN_COUNT=4)
 
 pico_generate_pio_header(picoprobe ${CMAKE_CURRENT_LIST_DIR}/src/probe.pio)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(picoprobe)
 pico_sdk_init()
 
 add_executable(picoprobe
+        src/led.c
         src/main.c
         src/usb_descriptors.c
         src/probe.c

--- a/src/led.c
+++ b/src/led.c
@@ -1,0 +1,36 @@
+#include <pico/stdlib.h>
+#include <stdint.h>
+
+#include "picoprobe_config.h"
+
+#define LED_COUNT_SHIFT 14
+#define LED_COUNT_MAX 5 * (1 << LED_COUNT_SHIFT)
+
+static uint32_t led_count;
+
+void led_init(void) {
+    led_count = 0;
+
+    gpio_init(PICOPROBE_LED);
+    gpio_set_dir(PICOPROBE_LED, GPIO_OUT);
+    gpio_put(PICOPROBE_LED, 1);
+}
+
+
+
+void led_task(void) {
+    if (led_count != 0) {
+        --led_count;
+        gpio_put(PICOPROBE_LED, !((led_count >> LED_COUNT_SHIFT) & 1));
+    }
+}
+
+void led_signal_activity(uint total_bits) {
+    if (led_count == 0) {
+        gpio_put(PICOPROBE_LED, 0);
+    }
+
+    if (led_count < LED_COUNT_MAX) {
+        led_count += total_bits;
+    }
+}

--- a/src/led.h
+++ b/src/led.h
@@ -1,0 +1,8 @@
+#ifndef LED_H
+#define LED_H
+
+void led_init(void);
+void led_task(void);
+void led_signal_activity(uint total_bits);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,7 @@
 #include "picoprobe_config.h"
 #include "probe.h"
 #include "cdc_uart.h"
+#include "led.h"
 
 // UART0 for Picoprobe debug
 // UART1 for picoprobe to target device
@@ -43,6 +44,7 @@ int main(void) {
     cdc_uart_init();
     tusb_init();
     probe_init();
+    led_init();
 
     picoprobe_info("Welcome to Picoprobe!\n");
 
@@ -50,6 +52,7 @@ int main(void) {
         tud_task(); // tinyusb device task
         cdc_task();
         probe_task();
+        led_task();
     }
 
     return 0;

--- a/src/picoprobe_config.h
+++ b/src/picoprobe_config.h
@@ -32,6 +32,6 @@
 #define PICOPROBE_UART_RX 5
 
 // LED config
-#define PICOPROBE_LED 25
+#define PICOPROBE_LED PICO_DEFAULT_LED_PIN
 
 #endif

--- a/src/picoprobe_config.h
+++ b/src/picoprobe_config.h
@@ -32,6 +32,16 @@
 #define PICOPROBE_UART_RX 5
 
 // LED config
+#ifndef PICOPROBE_LED
+
+#ifndef PICO_DEFAULT_LED_PIN
+#error PICO_DEFAULT_LED_PIN is not defined, run PICOPROBE_LED=<led_pin> cmake
+#elif PICO_DEFAULT_LED_PIN == -1
+#error PICO_DEFAULT_LED_PIN is defined as -1, run PICOPROBE_LED=<led_pin> cmake
+#else
 #define PICOPROBE_LED PICO_DEFAULT_LED_PIN
+#endif
+
+#endif
 
 #endif

--- a/src/picoprobe_config.h
+++ b/src/picoprobe_config.h
@@ -31,4 +31,7 @@
 #define PICOPROBE_UART_TX 4
 #define PICOPROBE_UART_RX 5
 
+// LED config
+#define PICOPROBE_LED 25
+
 #endif

--- a/src/probe.c
+++ b/src/probe.c
@@ -11,6 +11,7 @@
 #include <hardware/clocks.h>
 #include <hardware/gpio.h>
 
+#include "led.h"
 #include "picoprobe_config.h"
 #include "probe.pio.h"
 #include "tusb.h"
@@ -172,6 +173,9 @@ void probe_handle_read(uint total_bits) {
 
 void probe_handle_write(uint8_t *data, uint total_bits) {
     picoprobe_debug("Write %d bits\n", total_bits);
+
+    led_signal_activity(total_bits);
+
     probe_write_mode();
 
     uint chunk;


### PR DESCRIPTION
I think some positive confirmation that probe is working and doing something can be useful to users (especially if they are running multiple picoprobes at the same time)

This diff adds following features:
* Turns on LED (on GPIO 25) on successful initialization.
* Blinks the LED when write commands are issued. Constants in led.c are picked such that idle debugger connection doesn't cause visible blinking. However when firmware is being loaded to the debug target, the LED dims and blinks.

