### PR TITLE
Unique serial numbers for picoprobe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(picoprobe
         src/usb_descriptors.c
         src/probe.c
         src/cdc_uart.c
+        src/get_serial.c
 )
 
 set(DBG_PIN_COUNT=4)
@@ -19,6 +20,6 @@ pico_generate_pio_header(picoprobe ${CMAKE_CURRENT_LIST_DIR}/src/probe.pio)
 
 target_include_directories(picoprobe PRIVATE src)
 
-target_link_libraries(picoprobe PRIVATE pico_stdlib tinyusb_device tinyusb_board hardware_pio)
+target_link_libraries(picoprobe PRIVATE pico_stdlib pico_unique_id tinyusb_device tinyusb_board hardware_pio)
 
 pico_add_extra_outputs(picoprobe)

--- a/src/get_serial.c
+++ b/src/get_serial.c
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ * Copyright (c) 2021 Federico Zuccardi Merli
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,36 +23,28 @@
  *
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-
-#include "bsp/board.h"
-#include "tusb.h"
-
-#include "picoprobe_config.h"
-#include "probe.h"
-#include "cdc_uart.h"
+#include <stdint.h>
+#include "pico/unique_id.h"
 #include "get_serial.h"
 
-// UART0 for Picoprobe debug
-// UART1 for picoprobe to target device
+/* C string for iSerialNumber in USB Device Descriptor, two chars per byte + terminating NUL */
+char usb_serial[PICO_UNIQUE_BOARD_ID_SIZE_BYTES * 2 + 1];
 
-int main(void) {
+/* Why a uint8_t[8] array inside a struct instead of an uint64_t an inquiring mind might wonder */
+static pico_unique_board_id_t uID;
 
-    board_init();
-    usb_serial_init();
-    cdc_uart_init();
-    tusb_init();
-    probe_init();
+void usb_serial_init(void)
+{
+    pico_get_unique_board_id(&uID);
 
-    picoprobe_info("Welcome to Picoprobe!\n");
-
-    while (1) {
-        tud_task(); // tinyusb device task
-        cdc_task();
-        probe_task();
+    for (int i = 0; i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES * 2; i++)
+    {
+        /* Byte index inside the uid array */
+        int bi = i / 2;
+        /* Use high nibble first to keep memory order (just cosmetics) */
+        uint8_t nibble = (uID.id[bi] >> 4) & 0x0F;
+        uID.id[bi] <<= 4;
+        /* Binary to hex digit */
+        usb_serial[i] = nibble < 10 ? nibble + '0' : nibble + 'A' - 10;
     }
-
-    return 0;
 }

--- a/src/get_serial.h
+++ b/src/get_serial.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ * Copyright (c) 2021 Federico Zuccardi Merli
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,36 +23,13 @@
  *
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#ifndef GET_SERIAL_H_
+#define GET_SERIAL_H_
 
-#include "bsp/board.h"
-#include "tusb.h"
+/* Contains unique serial number string (NUL terminated) after call to init_usb_serial */
+extern char usb_serial[];
 
-#include "picoprobe_config.h"
-#include "probe.h"
-#include "cdc_uart.h"
-#include "get_serial.h"
+/* Fills unique_serial with the flash unique id */
+extern void usb_serial_init(void);
 
-// UART0 for Picoprobe debug
-// UART1 for picoprobe to target device
-
-int main(void) {
-
-    board_init();
-    usb_serial_init();
-    cdc_uart_init();
-    tusb_init();
-    probe_init();
-
-    picoprobe_info("Welcome to Picoprobe!\n");
-
-    while (1) {
-        tud_task(); // tinyusb device task
-        cdc_task();
-        probe_task();
-    }
-
-    return 0;
-}
+#endif

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -24,6 +24,7 @@
  */
 
 #include "tusb.h"
+#include "get_serial.h"
 
 
 //--------------------------------------------------------------------+
@@ -106,7 +107,7 @@ char const* string_desc_arr [] =
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
   "Raspberry Pi", // 1: Manufacturer
   "Picoprobe",    // 2: Product
-  "123456",       // 3: Serials, should use chip ID
+  usb_serial,     // 3: Serial, uses flash unique ID
 };
 
 static uint16_t _desc_str[32];


### PR DESCRIPTION
This PR (hinted at in the comments for #5)  makes the USB serial number for each Picoprobe unique.
It will come handy for multi probe support in pyocd.

Code is very simple, a direct conversion of the flash unique ID to a C string.

As far as I can see, there's no need to bracket the call to `pico_get_unique_board_id();` with disable/enable interrupt, as they seem not to be enabled (yet) when `usb_serial_init()` is called.