### PR TITLE
Hardware target reset support

### DIFF
--- a/src/picoprobe_config.h
+++ b/src/picoprobe_config.h
@@ -52,6 +52,9 @@
 #define PROBE_PIN_SWCLK PROBE_PIN_OFFSET + 0 // 2
 #define PROBE_PIN_SWDIO PROBE_PIN_OFFSET + 1 // 3
 
+// Target reset config
+#define PROBE_PIN_RESET 6
+
 // UART config
 #define PICOPROBE_UART_TX 4
 #define PICOPROBE_UART_RX 5


### PR DESCRIPTION
A small PR to introduce support for a hardware target reset.
Asserting and de-asserting the reset signal is controlled by a new probe USB command:
https://github.com/newbrain/picoprobe/blob/5f1630c390fbb912b625231d6c02fb7b3b538b27/src/probe.c#L76

If the value passed in the bits command header is false (0) the reset line is de-asserted (high).
If true (anything else) the reset line is asserted (low).

The reset pin is configured in `picoprobe_config.h`, currently GPIO 6:
https://github.com/newbrain/picoprobe/blob/5f1630c390fbb912b625231d6c02fb7b3b538b27/src/picoprobe_config.h#L55-L56
Open drain is simulated changing the pin direction from output (for low) to input (for high, with pull-up)

This can be easily added to OpenOCD, and I'll include it in pyOCD when I propose the picoprobe support PR.

Tested with a modified pyOCD and a scope.