### PR TITLE
Improve debugger performance

### DIFF
--- a/include/DAP_config.h
+++ b/include/DAP_config.h
@@ -95,7 +95,7 @@ This information includes:
 /// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
 /// setting can be reduced (valid range is 1 .. 255).
-#define DAP_PACKET_COUNT        2U              ///< Specifies number of packets buffered.
+#define DAP_PACKET_COUNT        255U              ///< Specifies number of packets buffered.
 
 /// Indicate that UART Serial Wire Output (SWO) trace is available.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.


### PR DESCRIPTION
DAP_PACKET_COUNT indicates the number of messages that the probe may have in flight at any time. With this set to 2, the computer is forced to send just two messages, wait for those messages to be replied to, and then submit remaining messages. Looks like in practice, a message is a single word flash read or write.

Since USB places a minimum bound of 2ms delay on each message, that comes out to an absolute max speed of 3.9KiB/s.

If we instead change this to allow 255 messages simultaniously in flight, we get a theoretical max of 500KiB/s since our pipeline is much wider.

Unfortunately, I think this is the best we can do with the RP2040 as the debugger. USB full-speed supports a max packet size of 64, so while DAP allows packets up to 1024 bytes, we can't do that because we'd have to use USB high-speed.