### PR TITLE
Implementation of CMSIS-DAPv2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(picoprobe
         src/cdc_uart.c
         src/get_serial.c
         src/sw_dp_pio.c
+        src/dap_util.c
 )
 
 target_sources(picoprobe PRIVATE

--- a/include/DAP_config.h
+++ b/include/DAP_config.h
@@ -47,6 +47,7 @@ This information includes:
 #include <hardware/gpio.h>
 
 #include "cmsis_compiler.h"
+#include "tusb_config.h"
 #include "picoprobe_config.h"
 #include "probe.h"
 
@@ -61,8 +62,7 @@ This information includes:
 /// require 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
 /// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be
 /// required.
-#define IO_PORT_WRITE_CYCLES    1U              ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0.
-#define DELAY_SLOW_CYCLES 1U // We don't differentiate between fast/slow, we've got a 16-bit divisor for that
+#define IO_PORT_WRITE_CYCLES    2U              ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0.
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
@@ -89,13 +89,23 @@ This information includes:
 /// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
 /// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
-#define DAP_PACKET_SIZE         64U            ///< Specifies Packet Size in bytes.
+/// TODO pyOCD: OK: 64, 128   /   FAIL: 256, 512, 1024   bug in pyOCD?
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V2)
+    #define DAP_PACKET_SIZE     512U           ///< Specifies Packet Size in bytes.
+#else
+    #define DAP_PACKET_SIZE     64U             ///< Specifies Packet Size in bytes.
+#endif
 
 /// Maximum Package Buffers for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
 /// setting can be reduced (valid range is 1 .. 255).
-#define DAP_PACKET_COUNT        2U              ///< Specifies number of packets buffered.
+/// 
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V2)
+    #define DAP_PACKET_COUNT    8U              ///< Specifies number of packets buffered.
+#else
+    #define DAP_PACKET_COUNT    2U              ///< Specifies number of packets buffered.
+#endif
 
 /// Indicate that UART Serial Wire Output (SWO) trace is available.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.

--- a/src/dap_util.c
+++ b/src/dap_util.c
@@ -1,0 +1,383 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+/**
+ * This is originated from CMSIS DAP.c because the CMSIS developers weren't capable of
+ * designing a protocol with contained length indication.
+ * Therefore these functions are doing nothing else then collecting the expected length
+ * of the _request_ from the already received data.  Length of generated response is
+ * not of interest.
+ * 
+ * BUT... problem still persists, see e.g. DAP_SWD_Sequence()
+ */
+
+#include <string.h>
+#include "DAP_config.h"
+#include "DAP.h"
+
+#include "dap_util.h"
+
+
+
+static uint32_t DAP_Check_JTAG_Sequence(const uint8_t *request, uint32_t request_len)
+{
+    uint32_t sequence_info;
+    uint32_t sequence_count;
+    uint32_t request_count;
+    uint32_t count;
+
+    if (request_len < 1 + 1)
+    {
+        return DAP_CHECK_ABORT;
+    }
+
+    request_count = 2U;
+    sequence_count = request[1];
+
+    request += 2;
+    while (sequence_count--)
+    {
+        if (request_count > request_len)
+        {
+            return DAP_CHECK_ABORT;
+        }
+
+        sequence_info = *request++;
+        count = sequence_info & JTAG_SEQUENCE_TCK;
+        if (count == 0U)
+        {
+            count = 64U;
+        }
+        count = (count + 7U) / 8U;
+        request += count;
+        request_count += count + 1U;
+    }
+
+    return request_count;
+}   // DAP_Check_JTAG_Sequence
+
+
+
+static uint32_t DAP_Check_SWD_Sequence(const uint8_t *request, uint32_t request_len) 
+{
+    uint32_t sequence_info;
+    uint32_t sequence_count;
+    uint32_t request_count;
+    uint32_t count;
+
+    if (request_len < 1 + 1)
+    {
+        return DAP_CHECK_ABORT;
+    }
+
+    request_count = 2U;
+    sequence_count = request[1];
+
+    request += 2;
+    while (sequence_count--)
+    {
+        if (request_len < request_count)
+        {
+            return DAP_CHECK_ABORT;
+        }
+
+        sequence_info = *request++;
+        count = sequence_info & SWD_SEQUENCE_CLK;
+        if (count == 0U)
+        {
+            count = 64U;
+        }
+        count = (count + 7U) / 8U;
+        if ((sequence_info & SWD_SEQUENCE_DIN) != 0U)
+        {
+            request_count++;
+        }
+        else
+        {
+            request += count;
+            request_count += count + 1U;
+        }
+    }
+
+    return request_count;
+}   // DAP_Check_SWD_Sequence
+
+
+
+static uint32_t DAP_Check_Transfer(const uint8_t *request, uint32_t request_len)
+{
+    const uint8_t *request_head;
+    uint32_t transfer_count;
+    uint32_t request_value;
+
+    if (request_len < 1 + 1 + 1 + 1)
+    {
+        return DAP_CHECK_ABORT;
+    }
+
+    request_head = request;
+
+    transfer_count = request[2];
+    
+    request += 3;
+    for (; transfer_count != 0U; transfer_count--)
+    {
+        if (request_len < request - request_head)
+        {
+            return DAP_CHECK_ABORT;
+        }
+
+        // Process dummy requests
+        request_value = *request++;
+        if ((request_value & DAP_TRANSFER_RnW) != 0U)
+        {
+            // Read register
+            if ((request_value & DAP_TRANSFER_MATCH_VALUE) != 0U)
+            {
+                // Read with value match
+                request += 4;
+            }
+        }
+        else
+        {
+            // Write register
+            request += 4;
+        }
+    }
+
+    return request - request_head;
+}   // DAP_Check_Transfer
+
+
+
+static uint32_t DAP_Check_TransferBlock(const uint8_t *request, uint32_t request_len) 
+{
+    uint32_t num;
+
+    if (request_len < 1 + 1 + 2 + 1)
+    {
+        return DAP_CHECK_ABORT;
+    }
+
+    if ((request[4] & DAP_TRANSFER_RnW) != 0U)
+    {
+        // Read register block
+        num = 5;
+    }
+    else
+    {
+        // Write register block
+        num = 5 + 4 * ((uint32_t)request[2]  |  (uint32_t)(request[3] << 8));
+    }
+
+    return num;
+}   // DAP_Check_TransferBlock
+
+
+
+/**
+ * Check the length of a vendor DAP request
+ * request:     pointer to available request data
+ * request_len: request data currently in buffer
+ * return:   number of bytes required for complete request or DAP_CHECK_ABORT if  not enough information
+ */
+__WEAK uint32_t DAP_Check_ProcessVendorCommand(const uint8_t *request, uint32_t request_len) 
+{
+    // actually this should result in an assertion (thanks to the protocol definition without length spec)
+    return 1;
+}   // DAP_Check_ProcessVendorCommand
+
+
+
+/**
+ * Get the length of a single DAP request
+ * request:     pointer to available request data
+ * request_len: request data currently in buffer
+ * return:   number of bytes required for complete request or DAP_CHECK_ABORT if  not enough information
+ */
+static uint32_t DAP_GetSingleCommandLength(const uint8_t *request, uint32_t request_len) 
+{
+    uint32_t num;
+
+    if (request[0] >= ID_DAP_Vendor0  &&  request[0] <= ID_DAP_Vendor31)
+    {
+        return DAP_Check_ProcessVendorCommand(request, request_len);
+    }
+
+    switch (request[0])
+    {
+        case ID_DAP_Info:
+            num = 1 + 1;
+            break;
+
+        case ID_DAP_HostStatus:
+            num = 1 + 1 + 1;
+            break;
+
+        case ID_DAP_Connect:
+            num = 1 + 1;
+            break;
+
+        case ID_DAP_Disconnect:
+            num = 1;
+            break;
+
+        case ID_DAP_Delay:
+            num = 1 + 2;
+            break;
+
+        case ID_DAP_ResetTarget:
+            num = 1;
+            break;
+
+        case ID_DAP_SWJ_Pins:
+            num = 1 + 1 + 1 + 4;
+            break;
+
+        case ID_DAP_SWJ_Clock:
+            num = 1 + 4;
+            break;
+
+        case ID_DAP_SWJ_Sequence:
+            if (request_len < 3)
+            {
+                num = DAP_CHECK_ABORT;
+            }
+            else
+            {
+                num = 1 + 1 + ((request[1] == 0 ? 256 : request[1]) + 7) / 8;
+            }
+            break;
+
+        case ID_DAP_SWD_Configure:
+            num = 1 + 1;
+            break;
+
+        case ID_DAP_SWD_Sequence:
+            num = DAP_Check_SWD_Sequence(request, request_len);
+            break;
+
+        case ID_DAP_JTAG_Sequence:
+            num = DAP_Check_JTAG_Sequence(request, request_len);
+            break;
+
+        case ID_DAP_JTAG_Configure:
+            num = 1 + 1 + 1;
+            break;
+
+        case ID_DAP_JTAG_IDCODE:
+            num = 1 + 1;
+            break;
+
+        case ID_DAP_TransferConfigure:
+            num = 1 + 1 + 2 + 2;
+            break;
+
+        case ID_DAP_Transfer:
+            num = DAP_Check_Transfer(request, request_len);
+            break;
+
+        case ID_DAP_TransferBlock:
+            num = DAP_Check_TransferBlock(request, request_len);
+            break;
+
+        case ID_DAP_TransferAbort:
+            num = 1;
+            break;
+
+        case ID_DAP_WriteABORT:
+            num = 2 + 4;
+            break;
+
+#if ((SWO_UART != 0) || (SWO_MANCHESTER != 0))
+        case ID_DAP_SWO_Transport:
+            num = 1 + 1;
+            break;
+
+        case ID_DAP_SWO_Mode:
+            num = 1 + 1;
+            break;
+
+        case ID_DAP_SWO_Baudrate:
+            num = 1 + 4;
+            break;
+
+        case ID_DAP_SWO_Control:
+            num = 1 + 1;
+            break;
+
+        case ID_DAP_SWO_Status:
+            num = 1;
+            break;
+
+        case ID_DAP_SWO_ExtendedStatus:
+            num = 1 + 1;
+            break;
+
+        case ID_DAP_SWO_Data:
+            num = 1 + 2;
+            break;
+#endif
+
+        default:
+            num = 1;
+            break;
+    }
+
+    return num;
+}   // DAP_GetSingleCommandLength
+
+
+
+// Get the length of a DAP request
+//   request:     pointer to available request data
+//   request_len: request data currently in buffer
+//   return:   number of bytes required for complete request or DAP_CHECK_ABORT if not enough information
+uint32_t DAP_GetCommandLength(const uint8_t *request, uint32_t request_len)
+{
+    uint32_t num_cmd, num, n;
+
+    if (*request == ID_DAP_ExecuteCommands)
+    {
+        num_cmd = request[1];
+        num = 2;
+        request += 2;
+        for (uint32_t c = 0;  c < num_cmd;  ++c)
+        {
+            if (num > request_len)
+            {
+                num = DAP_CHECK_ABORT;
+                break;
+            }
+            request_len -= num;
+            n = DAP_GetSingleCommandLength(request, request_len);
+            num += n;
+            request += n;
+        }
+        return (num > DAP_CHECK_ABORT) ? DAP_CHECK_ABORT : num;
+    }
+
+    return DAP_GetSingleCommandLength(request, request_len);
+}   // DAP_GetCommandLength

--- a/src/dap_util.h
+++ b/src/dap_util.h
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef DAP_UTIL_H
+#define DAP_UTIL_H
+
+#include <stdint.h>
+
+static const uint32_t DAP_CHECK_ABORT = 99999999;
+
+uint32_t DAP_GetCommandLength(const uint8_t *request_data, uint32_t request_len);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -77,7 +77,7 @@ void usb_thread(void *ptr)
     do {
         tud_task();
         // Trivial delay to save power
-        vTaskDelay(5);
+        vTaskDelay(1);
     } while (1);
 }
 
@@ -97,7 +97,7 @@ void dap_thread(void *ptr)
         }
         else
         {
-            // Trivial delay to save power
+            // Trivial delay to save power and allow schedule of other tasks
             vTaskDelay(1);
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -32,56 +32,114 @@
 #include <string.h>
 
 #include "bsp/board.h"
-#include "tusb.h"
 
-#include "picoprobe_config.h"
-#include "probe.h"
+#include "tusb.h"
+#include "time.h"
 #include "cdc_uart.h"
 #include "get_serial.h"
 #include "led.h"
 #include "DAP.h"
+#include "DAP_config.h"
+#include "tusb_config.h"
+#include "dap_util.h"
 
-// UART0 for Picoprobe debug
+
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_OPENOCD_CUSTOM)
+    #define THREADED 0                        // threaded is here not implemented
+#else
+    #define THREADED 1
+#endif
+
+
 // UART1 for picoprobe to target device
 
-static uint8_t TxDataBuffer[CFG_TUD_HID_EP_BUFSIZE];
-static uint8_t RxDataBuffer[CFG_TUD_HID_EP_BUFSIZE];
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V1)
+    static uint8_t TxDataBuffer[CFG_TUD_HID_EP_BUFSIZE * DAP_PACKET_COUNT];
+#elif (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V2)
+    static uint8_t TxDataBuffer[8192]; //DAP_PACKET_SIZE * DAP_PACKET_COUNT];    // TODO correct!?
+    static uint8_t RxDataBuffer[8192]; //DAP_PACKET_SIZE * DAP_PACKET_COUNT];
+    static TaskHandle_t dap_taskhandle;
+#endif
 
-#define THREADED 1
 
-#define UART_TASK_PRIO (tskIDLE_PRIORITY + 3)
-#define TUD_TASK_PRIO  (tskIDLE_PRIORITY + 2)
-#define DAP_TASK_PRIO  (tskIDLE_PRIORITY + 1)
+#if (THREADED != 0)
+    static TaskHandle_t tud_taskhandle;
 
-static TaskHandle_t dap_taskhandle, tud_taskhandle;
+    #define UART_TASK_PRIO (tskIDLE_PRIORITY + 1)
+    #define TUD_TASK_PRIO  (tskIDLE_PRIORITY + 2)
+    #define DAP_TASK_PRIO  (tskIDLE_PRIORITY + 3)
+#endif
+
+
 
 void usb_thread(void *ptr)
 {
     do {
         tud_task();
         // Trivial delay to save power
-        vTaskDelay(1);
+        vTaskDelay(5);
     } while (1);
 }
 
+
+
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V2)
 void dap_thread(void *ptr)
 {
-    uint32_t resp_len;
-    do {
-        if (tud_vendor_available()) {
-            tud_vendor_read(RxDataBuffer, sizeof(RxDataBuffer));
-            resp_len = DAP_ProcessCommand(RxDataBuffer, TxDataBuffer);
-            tud_vendor_write(TxDataBuffer, resp_len);
-        } else {
-            // Trivial delay to save power
-            vTaskDelay(2);
+    uint32_t rx_len;
+
+    rx_len = 0;
+    for (;;)
+    {
+        if (tud_vendor_available()) 
+        {
+            rx_len += tud_vendor_read(RxDataBuffer + rx_len, sizeof(RxDataBuffer));
         }
-    } while (1);
+        else
+        {
+            // Trivial delay to save power
+            vTaskDelay(1);
+        }
+
+        if (rx_len != 0)
+        {
+            uint32_t request_len;
+
+            request_len = DAP_GetCommandLength(RxDataBuffer, rx_len);
+            if (rx_len >= request_len)
+            {
+                uint32_t resp_len;
+
+                resp_len = DAP_ExecuteCommand(RxDataBuffer, TxDataBuffer);
+                tud_vendor_write(TxDataBuffer, resp_len & 0xffff);
+                tud_vendor_flush();
+
+                if (request_len != (resp_len >> 16))
+                {
+                    // there is a bug in CMSIS-DAP, see https://github.com/ARM-software/CMSIS_5/pull/1503
+                    // but we trust our own length calculation
+                    picoprobe_error("   !!!!!!!! request (%lu) and executed length (%lu) differ\n", request_len, resp_len >> 16);
+                }
+
+                if (rx_len == request_len)
+                {
+                    rx_len = 0;
+                }
+                else
+                {
+                    memmove(RxDataBuffer, RxDataBuffer + request_len, rx_len - request_len);
+                    rx_len -= request_len;
+                }
+            }
+        }
+    }
 }
+#endif
 
-int main(void) {
-    uint32_t resp_len;
 
+
+int main(void) 
+{
     board_init();
     usb_serial_init();
     cdc_uart_init();
@@ -94,108 +152,140 @@ int main(void) {
 #endif
     led_init();
 
-    picoprobe_info("Welcome to Picoprobe!\n");
+    picoprobe_info("\n-------------------------------------\n");
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_OPENOCD_CUSTOM)
+    picoprobe_info("    Welcome to Picoprobe - CUSTOM\n");
+#elif (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V1)
+    picoprobe_info("    Welcome to Picoprobe - DAP_V1\n");
+#elif (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V2)
+    picoprobe_info("    Welcome to Picoprobe - DAP_V2\n");
+#else
+    picoprobe_info("    Welcome to Picoprobe - UNKNOWN\n");
+#endif
+    picoprobe_info("           Target stopped\n");
+    picoprobe_info("-------------------------------------\n\n");
 
-    if (THREADED) {
-        /* UART needs to preempt USB as if we don't, characters get lost */
-        xTaskCreate(cdc_thread, "UART", configMINIMAL_STACK_SIZE, NULL, UART_TASK_PRIO, &uart_taskhandle);
-        xTaskCreate(usb_thread, "TUD", configMINIMAL_STACK_SIZE, NULL, TUD_TASK_PRIO, &tud_taskhandle);
-        /* Lowest priority thread is debug - need to shuffle buffers before we can toggle swd... */
-        xTaskCreate(dap_thread, "DAP", configMINIMAL_STACK_SIZE, NULL, DAP_TASK_PRIO, &dap_taskhandle);
-        vTaskStartScheduler();
-    }
+#if (THREADED != 0)
+    /* UART needs to preempt USB as if we don't, characters get lost */
+    xTaskCreate(cdc_thread, "UART", configMINIMAL_STACK_SIZE, NULL, UART_TASK_PRIO, &uart_taskhandle);
+    xTaskCreate(usb_thread, "TUD", configMINIMAL_STACK_SIZE, NULL, TUD_TASK_PRIO, &tud_taskhandle);
+    /* Lowest priority thread is debug - need to shuffle buffers before we can toggle swd... */
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V2)
+    xTaskCreate(dap_thread, "DAP", configMINIMAL_STACK_SIZE, NULL, DAP_TASK_PRIO, &dap_taskhandle);
+#endif
+    vTaskStartScheduler();
+#endif
 
-    while (!THREADED) {
+#if (THREADED == 0)
+    for (;;) {
         tud_task();
         cdc_task();
 #if (PICOPROBE_DEBUG_PROTOCOL == PROTO_OPENOCD_CUSTOM)
         probe_task();
         led_task();
 #elif (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V2)
-        if (tud_vendor_available()) {
-            tud_vendor_read(RxDataBuffer, sizeof(RxDataBuffer));
-            resp_len = DAP_ProcessCommand(RxDataBuffer, TxDataBuffer);
-            tud_vendor_write(TxDataBuffer, resp_len);
-        }
+        #error "PROTO_DAP_V2 does not work unthreaded"
 #endif
     }
+#endif
 
     return 0;
 }
 
+
+
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V1)
 uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
 {
-  // TODO not Implemented
-  (void) itf;
-  (void) report_id;
-  (void) report_type;
-  (void) buffer;
-  (void) reqlen;
+    // TODO not Implemented
+    (void)itf;
+    (void)report_id;
+    (void)report_type;
+    (void)buffer;
+    (void)reqlen;
 
-  return 0;
-}
-
-void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const* RxDataBuffer, uint16_t bufsize)
-{
-  uint32_t response_size = TU_MIN(CFG_TUD_HID_EP_BUFSIZE, bufsize);
-
-  // This doesn't use multiple report and report ID
-  (void) itf;
-  (void) report_id;
-  (void) report_type;
-
-  DAP_ProcessCommand(RxDataBuffer, TxDataBuffer);
-
-  tud_hid_report(0, TxDataBuffer, response_size);
-}
-
-#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V2)
-extern uint8_t const desc_ms_os_20[];
-
-bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request)
-{
-  // nothing to with DATA & ACK stage
-  if (stage != CONTROL_STAGE_SETUP) return true;
-
-  switch (request->bmRequestType_bit.type)
-  {
-    case TUSB_REQ_TYPE_VENDOR:
-      switch (request->bRequest)
-      {
-        case 1:
-          if ( request->wIndex == 7 )
-          {
-            // Get Microsoft OS 2.0 compatible descriptor
-            uint16_t total_len;
-            memcpy(&total_len, desc_ms_os_20+8, 2);
-
-            return tud_control_xfer(rhport, request, (void*) desc_ms_os_20, total_len);
-          }else
-          {
-            return false;
-          }
-
-        default: break;
-      }
-    break;
-    default: break;
-  }
-
-  // stall unknown request
-  return false;
+    return 0;
 }
 #endif
 
+
+
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V1)
+void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const *RxDataBuffer, uint16_t bufsize)
+{
+    uint32_t response_size = TU_MIN(CFG_TUD_HID_EP_BUFSIZE, bufsize);
+
+    // This doesn't use multiple report and report ID
+    (void)itf;
+    (void)report_id;
+    (void)report_type;
+
+    DAP_ExecuteCommand(RxDataBuffer, TxDataBuffer);
+    tud_hid_report(0, TxDataBuffer, response_size);
+}
+#endif
+
+
+
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V2)
+
+extern uint8_t const desc_ms_os_20[];
+
+bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const *request)
+{
+    // nothing to with DATA & ACK stage
+    if (stage != CONTROL_STAGE_SETUP)
+        return true;
+
+    switch (request->bmRequestType_bit.type)
+    {
+        case TUSB_REQ_TYPE_VENDOR:
+            switch (request->bRequest)
+            {
+                case 1:   // VENDOR_REQUEST_WEBUSB
+                    if (request->wIndex == 7)
+                    {
+                        // Get Microsoft OS 2.0 compatible descriptor
+                        uint16_t total_len;
+                        memcpy(&total_len, desc_ms_os_20 + 8, 2);
+
+                        return tud_control_xfer(rhport, request, (void *)desc_ms_os_20, total_len);
+                    }
+                    else
+                    {
+                        return false;
+                    }
+
+                default:
+                    break;
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    // stall unknown request
+    return false;
+}
+#endif
+
+
+
 void vApplicationTickHook (void)
 {
-};
+}
+
+
 
 void vApplicationStackOverflowHook(TaskHandle_t Task, char *pcTaskName)
 {
-  panic("stack overflow (not the helpful kind) for %s\n", *pcTaskName);
+    panic("stack overflow (not the helpful kind) for %s\n", *pcTaskName);
 }
+
+
 
 void vApplicationMallocFailedHook(void)
 {
-  panic("Malloc Failed\n");
-};
+    panic("Malloc Failed\n");
+}

--- a/src/picoprobe_config.h
+++ b/src/picoprobe_config.h
@@ -26,61 +26,57 @@
 #ifndef PICOPROBE_H_
 #define PICOPROBE_H_
 
-#if false
-#define picoprobe_info(format,args...) printf(format, ## args)
+#if 1
+    #define picoprobe_info(format,args...) printf(format, ## args)
 #else
-#define picoprobe_info(format,...) ((void)0)
+    #define picoprobe_info(format,...) ((void)0)
 #endif
 
-
-#if false
-#define picoprobe_debug(format,args...) printf(format, ## args)
+#if 0
+    #define picoprobe_debug(format,args...) printf(format, ## args)
 #else
-#define picoprobe_debug(format,...) ((void)0)
+    #define picoprobe_debug(format,...) ((void)0)
 #endif
 
-#if false
-#define picoprobe_dump(format,args...) printf(format, ## args)
+#if 0
+    #define picoprobe_dump(format,args...) printf(format, ## args)
 #else
-#define picoprobe_dump(format,...) ((void)0)
+    #define picoprobe_dump(format,...) ((void)0)
+#endif
+
+#if 1
+    #define picoprobe_error(format,args...) printf(format, ## args)
+#else
+    #define picoprobe_error(format,...) ((void)0)
 #endif
 
 
 // PIO config
-#define PROBE_SM 0
-#define PROBE_PIN_OFFSET 2
-#define PROBE_PIN_SWCLK (PROBE_PIN_OFFSET + 0) // 2
-#define PROBE_PIN_SWDIO (PROBE_PIN_OFFSET + 1) // 3
+#define PROBE_SM                    0
+#define PROBE_PIN_OFFSET            2
+#define PROBE_PIN_SWCLK             (PROBE_PIN_OFFSET + 0) // 2
+#define PROBE_PIN_SWDIO             (PROBE_PIN_OFFSET + 1) // 3
 
 // Target reset config
-#define PROBE_PIN_RESET 6
+#define PROBE_PIN_RESET             6
 
 // UART config
-#define PICOPROBE_UART_TX 4
-#define PICOPROBE_UART_RX 5
-#define PICOPROBE_UART_INTERFACE uart1
-#define PICOPROBE_UART_BAUDRATE 115200
+#define PICOPROBE_UART_TX           4
+#define PICOPROBE_UART_RX           5
+#define PICOPROBE_UART_INTERFACE    uart1
+#define PICOPROBE_UART_BAUDRATE     115200
 
 // LED config
 #ifndef PICOPROBE_LED
-
-#ifndef PICO_DEFAULT_LED_PIN
-#error PICO_DEFAULT_LED_PIN is not defined, run PICOPROBE_LED=<led_pin> cmake
-#elif PICO_DEFAULT_LED_PIN == -1
-#error PICO_DEFAULT_LED_PIN is defined as -1, run PICOPROBE_LED=<led_pin> cmake
-#else
-#define PICOPROBE_LED PICO_DEFAULT_LED_PIN
+    #ifndef PICO_DEFAULT_LED_PIN
+        #error PICO_DEFAULT_LED_PIN is not defined, run PICOPROBE_LED=<led_pin> cmake
+    #elif PICO_DEFAULT_LED_PIN == -1
+        #error PICO_DEFAULT_LED_PIN is defined as -1, run PICOPROBE_LED=<led_pin> cmake
+    #else
+        #define PICOPROBE_LED PICO_DEFAULT_LED_PIN
+    #endif
 #endif
 
-#define PROTO_OPENOCD_CUSTOM 0
-#define PROTO_DAP_V1 1
-#define PROTO_DAP_V2 2
-
-// Interface config
-#ifndef PICOPROBE_DEBUG_PROTOCOL
-#define PICOPROBE_DEBUG_PROTOCOL PROTO_DAP_V2
-#endif
-
-#endif
+// Attention: PICOPROBE_DEBUG_PROTOCOL moved to tusb_config.h
 
 #endif

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -27,7 +27,7 @@
 #define _TUSB_CONFIG_H_
 
 #ifdef __cplusplus
- extern "C" {
+    extern "C" {
 #endif
 
 //--------------------------------------------------------------------
@@ -36,46 +36,68 @@
 
 // defined by compiler flags for flexibility
 #ifndef CFG_TUSB_MCU
-  #error CFG_TUSB_MCU must be defined
+    #error CFG_TUSB_MCU must be defined
 #endif
 
-#define CFG_TUSB_RHPORT0_MODE     OPT_MODE_DEVICE
+#define CFG_TUSB_RHPORT0_MODE       (OPT_MODE_DEVICE | OPT_MODE_FULL_SPEED)
 
 #ifndef CFG_TUSB_OS
-#define CFG_TUSB_OS                 OPT_OS_PICO
+    #define CFG_TUSB_OS             OPT_OS_PICO
 #endif
 
 #ifndef CFG_TUSB_MEM_SECTION
-#define CFG_TUSB_MEM_SECTION
+    #define CFG_TUSB_MEM_SECTION
 #endif
 
 #ifndef CFG_TUSB_MEM_ALIGN
-#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+    #define CFG_TUSB_MEM_ALIGN      __attribute__ ((aligned(4)))
 #endif
 
 //--------------------------------------------------------------------
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
-#ifndef CFG_TUD_ENDPOINT0_SIZE
-#define CFG_TUD_ENDPOINT0_SIZE    64
+#define PROTO_OPENOCD_CUSTOM        0
+#define PROTO_DAP_V1                1
+#define PROTO_DAP_V2                2
+
+// Interface config
+#ifndef PICOPROBE_DEBUG_PROTOCOL
+    #define PICOPROBE_DEBUG_PROTOCOL PROTO_DAP_V2
 #endif
 
-//------------- CLASS -------------//
-#define CFG_TUD_HID             1
-#define CFG_TUD_CDC             1
-#define CFG_TUD_MSC             0
-#define CFG_TUD_MIDI            0
-#define CFG_TUD_VENDOR          1
+#if (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V1)
+    #define CFG_TUD_CDC             1
+    #define CFG_TUD_HID             1
+    #define CFG_TUD_MSC             0
+    #define CFG_TUD_MIDI            0
+    #define CFG_TUD_VENDOR          0
+#elif (PICOPROBE_DEBUG_PROTOCOL == PROTO_DAP_V2)
+    #define CFG_TUD_CDC             1
+    #define CFG_TUD_HID             0
+    #define CFG_TUD_MSC             0
+    #define CFG_TUD_MIDI            0
+    #define CFG_TUD_VENDOR          1
+#elif (PICOPROBE_DEBUG_PROTOCOL == PROTO_OPENOCD_CUSTOM)
+    #define CFG_TUD_CDC             1
+    #define CFG_TUD_HID             0
+    #define CFG_TUD_MSC             0
+    #define CFG_TUD_MIDI            0
+    #define CFG_TUD_VENDOR          1
+#endif
 
-#define CFG_TUD_CDC_RX_BUFSIZE 64
-#define CFG_TUD_CDC_TX_BUFSIZE 64
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+    #define CFG_TUD_ENDPOINT0_SIZE    64
+#endif
 
-#define CFG_TUD_VENDOR_RX_BUFSIZE 8192
-#define CFG_TUD_VENDOR_TX_BUFSIZE 8192
+#define CFG_TUD_CDC_RX_BUFSIZE        1024
+#define CFG_TUD_CDC_TX_BUFSIZE        1024
+
+#define CFG_TUD_VENDOR_RX_BUFSIZE     8192     // TODO don't know how big this should be
+#define CFG_TUD_VENDOR_TX_BUFSIZE     8192
 
 #ifdef __cplusplus
- }
+    }
 #endif
 
 #endif /* _TUSB_CONFIG_H_ */


### PR DESCRIPTION
CMSIS-DAPv2 should work by now.

Benefits (and motivation) of CMSIS-DAPv2:
- faster compared to HID based CMSIS-DAP by a factor of 3 to 4.  This means much faster upload and smoother debugging
- no driver on host side required, so no fiddling with Zadeg under Windows
- standard based, so tooling which support CMSIS-DAPv2 should work out of the box (exceptions below)

Impact(s):
- there are some problems with the RP2040 toolchain around: Earles openocd does not work with DAPv2, so this one has to be compiled again
- pyodc is very slow and depends strongly on DAP_PACKET_SIZE because pyocd seems to issue wrong DAP commands on buffer sizes > 128.

Note(s):
- selection of PICOPROBE_DEBUG_PROTOCOL moved to tusb_config.h because that gave less problems with the #includes
- reception of big DAPv2 requests:
  - because the CMSIS-DAP protocol does not contain any length indication, the reading of the 64byte USB chunks must know somehow else the expected request length. This is done in dap_util
  - reception also takes care if there are multiple requests in the buffer although I never saw this happening
  - responses are transmitted one by one
- to be honest, I have no clue about tinyusb, so the buffer (sizes) are all guess work
- I have not observed any benefit in increase of DAP_PACKET_COUNT, not sure, if the tools (openocd, pyocd) are using this. So this is actually untested