### PR TITLE
Probe debug output goes into CDC with timestamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ add_executable(picoprobe
         src/sw_dp_pio.c
 )
 
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+        target_sources(picoprobe PRIVATE
+                src/cdc_debug.c
+                )
+endif()
+
 target_sources(picoprobe PRIVATE
         CMSIS_5/CMSIS/DAP/Firmware/Source/DAP.c
         CMSIS_5/CMSIS/DAP/Firmware/Source/JTAG_DP.c

--- a/src/cdc_debug.c
+++ b/src/cdc_debug.c
@@ -126,7 +126,7 @@ int cdc_debug_printf(const char* format, ...)
     static bool newline = true;
     uint32_t now_ms;
     uint32_t d_ms;
-    char buf[256];
+    char buf[100];
     char tbuf[30];
     int cnt;
     int ndx = 0;

--- a/src/cdc_debug.c
+++ b/src/cdc_debug.c
@@ -1,0 +1,183 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include <stdarg.h>
+#include <pico/stdlib.h>
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "tusb.h"
+
+#include "picoprobe_config.h"
+
+
+#define CDC_DEBUG_N    1
+
+TaskHandle_t cdc_debug_taskhandle;
+
+static uint16_t cdc_debug_fifo_read;
+static uint16_t cdc_debug_fifo_write;
+static uint8_t cdc_debug_fifo[4096];
+static uint8_t cdc_debug_buf[CFG_TUD_CDC_TX_BUFSIZE];
+
+
+
+bool cdc_debug_task(void)
+/**
+ * Transmit debug output via CDC with a timestamp on each line.
+ * \return true -> characters have been transmitted
+ */
+{
+    static int was_connected = 0;
+    bool chars_sent = false;
+
+    if (tud_cdc_n_connected(CDC_DEBUG_N)) {
+        was_connected = 1;
+        if (cdc_debug_fifo_read != cdc_debug_fifo_write) {
+            int cnt;
+
+            if (cdc_debug_fifo_read > cdc_debug_fifo_write) {
+                cnt = sizeof(cdc_debug_fifo) - cdc_debug_fifo_read;
+            } else {
+                cnt = cdc_debug_fifo_write - cdc_debug_fifo_read;
+            }
+            cnt = MIN(cnt, sizeof(cdc_debug_buf));
+            cnt = MIN(tud_cdc_n_write_available(CDC_DEBUG_N), cnt);
+            memcpy(cdc_debug_buf, cdc_debug_fifo + cdc_debug_fifo_read, cnt);
+            cdc_debug_fifo_read = (cdc_debug_fifo_read + cnt) % sizeof(cdc_debug_fifo);
+            tud_cdc_n_write(CDC_DEBUG_N, cdc_debug_buf, cnt);
+            tud_cdc_n_write_flush(CDC_DEBUG_N);
+            chars_sent = true;
+        }
+    } else if (was_connected) {
+        tud_cdc_n_write_clear(CDC_DEBUG_N);
+        was_connected = 0;
+    }
+    return chars_sent;
+}   // cdc_debug_task
+
+
+
+void cdc_debug_thread(void* ptr)
+{
+    for (;;) {
+        if (cdc_debug_task())
+            vTaskDelay(1);
+        else
+            vTaskDelay((10 * configTICK_RATE_HZ) / 1000);          // 10ms
+    }
+}   // cdc_debug_thread
+
+
+
+static void cdc_to_fifo(const char* buf, int max_cnt)
+{
+    const char* buf_pnt;
+    int cnt;
+
+    buf_pnt = buf;
+    while (max_cnt > 0 && (cdc_debug_fifo_write + 1) % sizeof(cdc_debug_fifo) != cdc_debug_fifo_read) {
+        if (cdc_debug_fifo_read > cdc_debug_fifo_write) {
+            cnt = (cdc_debug_fifo_read - 1) - cdc_debug_fifo_write;
+        } else {
+            cnt = sizeof(cdc_debug_fifo) - cdc_debug_fifo_write;
+        }
+        cnt = MIN(cnt, max_cnt);
+        memcpy(cdc_debug_fifo + cdc_debug_fifo_write, buf_pnt, cnt);
+        buf_pnt += cnt;
+        max_cnt -= cnt;
+        cdc_debug_fifo_write = (cdc_debug_fifo_write + cnt) % sizeof(cdc_debug_fifo);
+    }
+} // cdc_to_fifo
+
+
+
+int cdc_debug_printf(const char* format, ...)
+/**
+ * Debug printf()
+ * Note that at the beginning of each output a timestamp is inserted.  Which means, that each call to cdc_printf()
+ * should output a line.
+ */
+{
+    static uint32_t prev_ms;
+    static uint32_t base_ms;
+    static bool newline = true;
+    uint32_t now_ms;
+    uint32_t d_ms;
+    char buf[256];
+    char tbuf[30];
+    int cnt;
+    int ndx = 0;
+    const char* p;
+
+    //
+    // print formatted text into buffer
+    //
+    va_list va;
+    va_start(va, format);
+    const int total_cnt = vsnprintf((char*)buf, sizeof(buf), format, va);
+    va_end(va);
+
+    tbuf[0] = 0;
+
+    while (ndx < total_cnt) {
+        if (newline) {
+            newline = false;
+
+            if (tbuf[0] == 0) {
+                //
+                // more or less intelligent time stamp which allows better measurements:
+                // - show delta
+                // - reset time if there hase been no activity for 5s
+                //
+                now_ms = (uint32_t)(time_us_64() / 1000) - base_ms;
+                if (now_ms - prev_ms > 5000) {
+                    base_ms = (uint32_t)(time_us_64() / 1000);
+                    now_ms = 0;
+                    prev_ms = 0;
+                }
+                d_ms = (uint32_t)(now_ms - prev_ms);
+                d_ms = MIN(d_ms, 999);
+                snprintf(tbuf, sizeof(tbuf), "%lu.%03lu (%3lu) - ", now_ms / 1000, now_ms % 1000, d_ms);
+                prev_ms = now_ms;
+            }
+            cdc_to_fifo(tbuf, strnlen(tbuf, sizeof(tbuf)));
+        }
+
+        p = memchr(buf + ndx, '\n', total_cnt - ndx);
+        if (p == NULL) {
+            cnt = total_cnt - ndx;
+        } else {
+            cnt = (p - (buf + ndx)) + 1;
+            newline = true;
+        }
+
+        cdc_to_fifo(buf + ndx, cnt);
+
+        ndx += cnt;
+    }
+
+    return total_cnt;
+} // cdc_debug_printf

--- a/src/cdc_debug.h
+++ b/src/cdc_debug.h
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef CDC_DEBUG_H
+#define CDC_DEBUG_H
+
+int cdc_debug_printf(const char* format, ...) __attribute__ ((format (printf, 1, 2)));
+
+bool cdc_debug_task(void);
+void cdc_debug_thread(void *ptr);
+
+extern TaskHandle_t cdc_debug_taskhandle;
+
+#endif

--- a/src/cdc_uart.c
+++ b/src/cdc_uart.c
@@ -106,7 +106,7 @@ void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const* line_coding)
   /* Modifying state, so park the thread before changing it. */
   vTaskSuspend(uart_taskhandle);
   interval = MAX(1, micros / ((1000 * 1000) / configTICK_RATE_HZ));
-  picoprobe_info("New baud rate %d micros %d interval %u\n",
+  picoprobe_info("New baud rate %lu micros %lu interval %lu\n",
                   line_coding->bit_rate, micros, interval);
   uart_deinit(PICOPROBE_UART_INTERFACE);
   tud_cdc_write_clear();

--- a/src/cdc_uart.c
+++ b/src/cdc_uart.c
@@ -23,7 +23,6 @@
  *
  */
 
-#include <stdarg.h>
 #include <pico/stdlib.h>
 #include "FreeRTOS.h"
 #include "task.h"
@@ -38,29 +37,21 @@ TickType_t last_wake, interval = 100;
 static uint8_t tx_buf[CFG_TUD_CDC_TX_BUFSIZE];
 static uint8_t rx_buf[CFG_TUD_CDC_RX_BUFSIZE];
 
-static uint16_t cdc_debug_fifo_read;
-static uint16_t cdc_debug_fifo_write;
-static uint8_t cdc_debug_fifo[4096];
-static uint8_t cdc_debug_buf[CFG_TUD_CDC_TX_BUFSIZE];
-
-void cdc_uart_init(void)
-{
+void cdc_uart_init(void) {
     gpio_set_function(PICOPROBE_UART_TX, GPIO_FUNC_UART);
     gpio_set_function(PICOPROBE_UART_RX, GPIO_FUNC_UART);
     gpio_set_pulls(PICOPROBE_UART_TX, 1, 0);
     gpio_set_pulls(PICOPROBE_UART_RX, 1, 0);
     uart_init(PICOPROBE_UART_INTERFACE, PICOPROBE_UART_BAUDRATE);
-    cdc_debug_fifo_read = 0;
-    cdc_debug_fifo_write = 0;
 }
 
 void cdc_task(void)
 {
     static int was_connected = 0;
-    static uint32_t rx_len = 0;
+    uint rx_len = 0;
 
     // Consume uart fifo regardless even if not connected
-    while (uart_is_readable(PICOPROBE_UART_INTERFACE) && (rx_len < sizeof(rx_buf))) {
+    while(uart_is_readable(PICOPROBE_UART_INTERFACE) && (rx_len < sizeof(rx_buf))) {
         rx_buf[rx_len++] = uart_getc(PICOPROBE_UART_INTERFACE);
     }
 
@@ -70,170 +61,66 @@ void cdc_task(void)
         /* Implicit overflow if we don't write all the bytes to the host.
          * Also throw away bytes if we can't write... */
         if (rx_len) {
-            written = MIN(tud_cdc_write_available(), rx_len);
-            if (written > 0) {
-                tud_cdc_write(rx_buf, written);
-                tud_cdc_write_flush();
-                memmove(rx_buf, rx_buf + written, rx_len - written);
-                rx_len -= written;
-            }
-        } else if (cdc_debug_fifo_read != cdc_debug_fifo_write) {
-            int cnt;
-
-            if (cdc_debug_fifo_read > cdc_debug_fifo_write) {
-                cnt = sizeof(cdc_debug_fifo) - cdc_debug_fifo_read;
-            } else {
-                cnt = cdc_debug_fifo_write - cdc_debug_fifo_read;
-            }
-            cnt = MIN(cnt, sizeof(cdc_debug_buf));
-            cnt = MIN(tud_cdc_write_available(), cnt);
-            memcpy(cdc_debug_buf, cdc_debug_fifo + cdc_debug_fifo_read, cnt);
-            cdc_debug_fifo_read = (cdc_debug_fifo_read + cnt) % sizeof(cdc_debug_fifo);
-            tud_cdc_write(cdc_debug_buf, cnt);
+          written = MIN(tud_cdc_write_available(), rx_len);
+          if (written > 0) {
+            tud_cdc_write(rx_buf, written);
             tud_cdc_write_flush();
+          }
         }
 
-        /* Reading from a firehose and writing to a FIFO. */
-        size_t watermark = MIN(tud_cdc_available(), sizeof(tx_buf));
-        if (watermark > 0) {
-            size_t tx_len;
-            /* Batch up to half a FIFO of data - don't clog up on RX */
-            watermark = MIN(watermark, 16);
-            tx_len = tud_cdc_read(tx_buf, watermark);
-            uart_write_blocking(PICOPROBE_UART_INTERFACE, tx_buf, tx_len);
-        }
+      /* Reading from a firehose and writing to a FIFO. */
+      size_t watermark = MIN(tud_cdc_available(), sizeof(tx_buf));
+      if (watermark > 0) {
+        size_t tx_len;
+        /* Batch up to half a FIFO of data - don't clog up on RX */
+        watermark = MIN(watermark, 16);
+        tx_len = tud_cdc_read(tx_buf, watermark);
+        uart_write_blocking(PICOPROBE_UART_INTERFACE, tx_buf, tx_len);
+      }
     } else if (was_connected) {
-        tud_cdc_write_clear();
-        was_connected = 0;
+      tud_cdc_write_clear();
+      was_connected = 0;
     }
 }
 
-void cdc_thread(void* ptr)
+void cdc_thread(void *ptr)
 {
-    BaseType_t delayed;
-    last_wake = xTaskGetTickCount();
-    /* Threaded with a polling interval that scales according to linerate */
-    while (1) {
-        cdc_task();
-        delayed = xTaskDelayUntil(&last_wake, interval);
-        if (delayed == pdFALSE)
-            last_wake = xTaskGetTickCount();
-    }
+  BaseType_t delayed;
+  last_wake = xTaskGetTickCount();
+  /* Threaded with a polling interval that scales according to linerate */
+  while (1) {
+    cdc_task();
+    delayed = xTaskDelayUntil(&last_wake, interval);
+    if (delayed == pdFALSE)
+      last_wake = xTaskGetTickCount();
+  }
 }
 
 void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const* line_coding)
 {
-    /* Set the tick thread interval to the amount of time it takes to
-     * fill up half a FIFO. Millis is too coarse for integer divide.
-     */
-    uint32_t micros = (1000 * 1000 * 16 * 10) / MAX(line_coding->bit_rate, 1);
+  /* Set the tick thread interval to the amount of time it takes to
+   * fill up half a FIFO. Millis is too coarse for integer divide.
+   */
+  uint32_t micros = (1000 * 1000 * 16 * 10) / MAX(line_coding->bit_rate, 1);
 
-    /* Modifying state, so park the thread before changing it. */
-    vTaskSuspend(uart_taskhandle);
-    interval = MAX(1, micros / ((1000 * 1000) / configTICK_RATE_HZ));
-    picoprobe_info("New baud rate %lu micros %lu interval %lu\n",
-        line_coding->bit_rate, micros, interval);
-    uart_deinit(PICOPROBE_UART_INTERFACE);
-    tud_cdc_write_clear();
-    tud_cdc_read_flush();
-    uart_init(PICOPROBE_UART_INTERFACE, line_coding->bit_rate);
-    vTaskResume(uart_taskhandle);
+  /* Modifying state, so park the thread before changing it. */
+  vTaskSuspend(uart_taskhandle);
+  interval = MAX(1, micros / ((1000 * 1000) / configTICK_RATE_HZ));
+  picoprobe_info("New baud rate %d micros %d interval %u\n",
+                  line_coding->bit_rate, micros, interval);
+  uart_deinit(PICOPROBE_UART_INTERFACE);
+  tud_cdc_write_clear();
+  tud_cdc_read_flush();
+  uart_init(PICOPROBE_UART_INTERFACE, line_coding->bit_rate);
+  vTaskResume(uart_taskhandle);
 }
 
 void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
 {
-    /* CDC drivers use linestate as a bodge to activate/deactivate the interface.
-     * Resume our UART polling on activate, stop on deactivate */
-    if (!dtr && !rts)
-        vTaskSuspend(uart_taskhandle);
-    else
-        vTaskResume(uart_taskhandle);
+  /* CDC drivers use linestate as a bodge to activate/deactivate the interface.
+   * Resume our UART polling on activate, stop on deactivate */
+  if (!dtr && !rts)
+    vTaskSuspend(uart_taskhandle);
+  else
+    vTaskResume(uart_taskhandle);
 }
-
-void cdc_to_fifo(const char* buf, int max_cnt)
-{
-    const char* buf_pnt;
-    int cnt;
-
-    buf_pnt = buf;
-    while (max_cnt > 0 && (cdc_debug_fifo_write + 1) % sizeof(cdc_debug_fifo) != cdc_debug_fifo_read) {
-        if (cdc_debug_fifo_read > cdc_debug_fifo_write) {
-            cnt = (cdc_debug_fifo_read - 1) - cdc_debug_fifo_write;
-        } else {
-            cnt = sizeof(cdc_debug_fifo) - cdc_debug_fifo_write;
-        }
-        cnt = MIN(cnt, max_cnt);
-        memcpy(cdc_debug_fifo + cdc_debug_fifo_write, buf_pnt, cnt);
-        buf_pnt += cnt;
-        max_cnt -= cnt;
-        cdc_debug_fifo_write = (cdc_debug_fifo_write + cnt) % sizeof(cdc_debug_fifo);
-    }
-} // cdc_to_fifo
-
-int cdc_printf(const char* format, ...)
-/**
- * Debug printf()
- * Note that at the beginning of each output a timestamp is inserted.  Which means, that each call to cdc_printf()
- * should output a line.
- */
-{
-    static uint32_t prev_ms;
-    static uint32_t base_ms;
-    static bool newline = true;
-    uint32_t now_ms;
-    uint32_t d_ms;
-    char buf[256];
-    char tbuf[30];
-    int cnt;
-    int ndx = 0;
-    const char* p;
-
-    //
-    // print formatted text into buffer
-    //
-    va_list va;
-    va_start(va, format);
-    const int total_cnt = vsnprintf((char*)buf, sizeof(buf), format, va);
-    va_end(va);
-
-    tbuf[0] = 0;
-
-    while (ndx < total_cnt) {
-        if (newline) {
-            newline = false;
-
-            if (tbuf[0] == 0) {
-                //
-                // more or less intelligent time stamp which allows better measurements:
-                // - show delta
-                // - reset time if there hase been no activity for 5s
-                //
-                now_ms = (uint32_t)(time_us_64() / 1000) - base_ms;
-                if (now_ms - prev_ms > 5000) {
-                    base_ms = (uint32_t)(time_us_64() / 1000);
-                    now_ms = 0;
-                    prev_ms = 0;
-                }
-                d_ms = (uint32_t)(now_ms - prev_ms);
-                d_ms = MIN(d_ms, 999);
-                snprintf(tbuf, sizeof(tbuf), "%lu.%03lu (%3lu) - ", now_ms / 1000, now_ms % 1000, d_ms);
-                prev_ms = now_ms;
-            }
-            cdc_to_fifo(tbuf, strnlen(tbuf, sizeof(tbuf)));
-        }
-
-        p = memchr(buf + ndx, '\n', total_cnt - ndx);
-        if (p == NULL) {
-            cnt = total_cnt - ndx;
-        } else {
-            cnt = (p - (buf + ndx)) + 1;
-            newline = true;
-        }
-
-        cdc_to_fifo(buf + ndx, cnt);
-
-        ndx += cnt;
-    }
-
-    return total_cnt;
-} // cdc_printf

--- a/src/main.c
+++ b/src/main.c
@@ -102,12 +102,12 @@ int main(void) {
 
     if (THREADED) {
         /* UART needs to preempt USB as if we don't, characters get lost */
-        xTaskCreate(cdc_thread, "UART", configMINIMAL_STACK_SIZE, NULL, UART_TASK_PRIO, &uart_taskhandle);
-        xTaskCreate(usb_thread, "TUD", configMINIMAL_STACK_SIZE, NULL, TUD_TASK_PRIO, &tud_taskhandle);
+        xTaskCreate(cdc_thread, "UART", configMINIMAL_STACK_SIZE+512, NULL, UART_TASK_PRIO, &uart_taskhandle);
+        xTaskCreate(usb_thread, "TUD", configMINIMAL_STACK_SIZE+512, NULL, TUD_TASK_PRIO, &tud_taskhandle);
         /* Lowest priority thread is debug - need to shuffle buffers before we can toggle swd... */
-        xTaskCreate(dap_thread, "DAP", configMINIMAL_STACK_SIZE, NULL, DAP_TASK_PRIO, &dap_taskhandle);
+        xTaskCreate(dap_thread, "DAP", configMINIMAL_STACK_SIZE+512, NULL, DAP_TASK_PRIO, &dap_taskhandle);
 #if !defined(NDEBUG)
-        xTaskCreate(cdc_debug_thread, "CDC_DEB", configMINIMAL_STACK_SIZE, NULL, CDC_DEBUG_TASK_PRIO, &cdc_debug_taskhandle);
+        xTaskCreate(cdc_debug_thread, "CDC_DEB", configMINIMAL_STACK_SIZE+512, NULL, CDC_DEBUG_TASK_PRIO, &cdc_debug_taskhandle);
 #endif
         vTaskStartScheduler();
     }

--- a/src/picoprobe_config.h
+++ b/src/picoprobe_config.h
@@ -26,30 +26,32 @@
 #ifndef PICOPROBE_H_
 #define PICOPROBE_H_
 
-int cdc_printf(const char* format, ...) __attribute__ ((format (printf, 1, 2)));
-
-#if false
-#define picoprobe_info(format,args...) cdc_printf(format, ## args)
-#else
-#define picoprobe_info(format,...) ((void)0)
+#if !defined(NDEBUG)
+    int cdc_debug_printf(const char* format, ...) __attribute__ ((format (printf, 1, 2)));
 #endif
 
-#if false
-#define picoprobe_debug(format,args...) cdc_printf(format, ## args)
+#if 1  &&  !defined(NDEBUG)
+    #define picoprobe_info(format,args...) cdc_debug_printf(format, ## args)
 #else
-#define picoprobe_debug(format,...) ((void)0)
+    #define picoprobe_info(format,...) ((void)0)
 #endif
 
-#if false
-#define picoprobe_dump(format,args...) cdc_printf(format, ## args)
+#if 0  &&  !defined(NDEBUG)
+    #define picoprobe_debug(format,args...) cdc_debug_printf(format, ## args)
 #else
-#define picoprobe_dump(format,...) ((void)0)
+    #define picoprobe_debug(format,...) ((void)0)
 #endif
 
-#if false
-#define picoprobe_error(format,args...) cdc_printf(format, ## args)
+#if 0  &&  !defined(NDEBUG)
+    #define picoprobe_dump(format,args...) cdc_debug_printf(format, ## args)
 #else
-#define picoprobe_error(format,...) ((void)0)
+    #define picoprobe_dump(format,...) ((void)0)
+#endif
+
+#if 1  &&  !defined(NDEBUG)
+    #define picoprobe_error(format,args...) cdc_debug_printf(format, ## args)
+#else
+    #define picoprobe_error(format,...) ((void)0)
 #endif
 
 
@@ -70,24 +72,22 @@ int cdc_printf(const char* format, ...) __attribute__ ((format (printf, 1, 2)));
 
 // LED config
 #ifndef PICOPROBE_LED
+    #ifndef PICO_DEFAULT_LED_PIN
+        #error PICO_DEFAULT_LED_PIN is not defined, run PICOPROBE_LED=<led_pin> cmake
+    #elif PICO_DEFAULT_LED_PIN == -1
+        #error PICO_DEFAULT_LED_PIN is defined as -1, run PICOPROBE_LED=<led_pin> cmake
+    #else
+        #define PICOPROBE_LED PICO_DEFAULT_LED_PIN
+    #endif
 
-#ifndef PICO_DEFAULT_LED_PIN
-#error PICO_DEFAULT_LED_PIN is not defined, run PICOPROBE_LED=<led_pin> cmake
-#elif PICO_DEFAULT_LED_PIN == -1
-#error PICO_DEFAULT_LED_PIN is defined as -1, run PICOPROBE_LED=<led_pin> cmake
-#else
-#define PICOPROBE_LED PICO_DEFAULT_LED_PIN
-#endif
+    #define PROTO_OPENOCD_CUSTOM 0
+    #define PROTO_DAP_V1 1
+    #define PROTO_DAP_V2 2
 
-#define PROTO_OPENOCD_CUSTOM 0
-#define PROTO_DAP_V1 1
-#define PROTO_DAP_V2 2
-
-// Interface config
-#ifndef PICOPROBE_DEBUG_PROTOCOL
-#define PICOPROBE_DEBUG_PROTOCOL PROTO_DAP_V2
-#endif
-
+    // Interface config
+    #ifndef PICOPROBE_DEBUG_PROTOCOL
+        #define PICOPROBE_DEBUG_PROTOCOL PROTO_DAP_V2
+    #endif
 #endif
 
 #endif

--- a/src/picoprobe_config.h
+++ b/src/picoprobe_config.h
@@ -26,23 +26,30 @@
 #ifndef PICOPROBE_H_
 #define PICOPROBE_H_
 
+int cdc_printf(const char* format, ...) __attribute__ ((format (printf, 1, 2)));
+
 #if false
-#define picoprobe_info(format,args...) printf(format, ## args)
+#define picoprobe_info(format,args...) cdc_printf(format, ## args)
 #else
 #define picoprobe_info(format,...) ((void)0)
 #endif
 
-
 #if false
-#define picoprobe_debug(format,args...) printf(format, ## args)
+#define picoprobe_debug(format,args...) cdc_printf(format, ## args)
 #else
 #define picoprobe_debug(format,...) ((void)0)
 #endif
 
 #if false
-#define picoprobe_dump(format,args...) printf(format, ## args)
+#define picoprobe_dump(format,args...) cdc_printf(format, ## args)
 #else
 #define picoprobe_dump(format,...) ((void)0)
+#endif
+
+#if false
+#define picoprobe_error(format,args...) cdc_printf(format, ## args)
+#else
+#define picoprobe_error(format,...) ((void)0)
 #endif
 
 

--- a/src/probe.c
+++ b/src/probe.c
@@ -106,7 +106,7 @@ void probe_write_bits(uint bit_count, uint32_t data_byte) {
     pio_sm_put_blocking(pio0, PROBE_SM, bit_count - 1);
     pio_sm_put_blocking(pio0, PROBE_SM, data_byte);
     DEBUG_PINS_SET(probe_timing, DBG_PIN_WRITE_WAIT);
-    picoprobe_dump("Write %d bits 0x%x\n", bit_count, data_byte);
+    picoprobe_dump("Write %u bits 0x%lx\n", bit_count, data_byte);
     // Wait for pio to push garbage to rx fifo so we know it has finished sending
     pio_sm_get_blocking(pio0, PROBE_SM);
     DEBUG_PINS_CLR(probe_timing, DBG_PIN_WRITE_WAIT);
@@ -122,7 +122,7 @@ uint32_t probe_read_bits(uint bit_count) {
         data_shifted = data >> (32 - bit_count);
     }
 
-    picoprobe_dump("Read %d bits 0x%x (shifted 0x%x)\n", bit_count, data, data_shifted);
+    picoprobe_dump("Read %u bits 0x%lx (shifted 0x%lx)\n", bit_count, data, data_shifted);
     DEBUG_PINS_CLR(probe_timing, DBG_PIN_READ);
     return data_shifted;
 }

--- a/src/sw_dp_pio.c
+++ b/src/sw_dp_pio.c
@@ -47,7 +47,7 @@ void SWJ_Sequence (uint32_t count, const uint8_t *data) {
     probe_set_swclk_freq(MAKE_KHZ(DAP_Data.clock_delay));
     cached_delay = DAP_Data.clock_delay;
   }
-  picoprobe_debug("SWJ sequence count = %d FDB=0x%2x\n", count, data[0]);
+  picoprobe_debug("SWJ sequence count = %lu FDB=0x%2x\n", count, data[0]);
   n = count;
   while (n > 0) {
     if (n > 8)
@@ -151,7 +151,7 @@ uint8_t SWD_Transfer (uint32_t request, uint32_t *data) {
       }
       if (data)
         *data = val;
-      picoprobe_debug("Read %02x ack %02x 0x%08x parity %01x\n",
+      picoprobe_debug("Read %02x ack %02x 0x%08lx parity %01x\n",
                       prq, ack, val, bit);
       /* Turnaround for line idle */
       probe_read_bits(DAP_Data.swd_conf.turnaround);
@@ -167,7 +167,7 @@ uint8_t SWD_Transfer (uint32_t request, uint32_t *data) {
       parity = __builtin_popcount(val);
       /* Write Parity Bit */
       probe_write_bits(1, parity & 0x1);
-      picoprobe_debug("write %02x ack %02x 0x%08x parity %01x\n",
+      picoprobe_debug("write %02x ack %02x 0x%08lx parity %01lx\n",
                       prq, ack, val, parity);
     }
     /* Capture Timestamp */

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -63,7 +63,11 @@
 
 //------------- CLASS -------------//
 #define CFG_TUD_HID             1
-#define CFG_TUD_CDC             1
+#if !defined(NDEBUG)
+    #define CFG_TUD_CDC         2
+#else
+    #define CFG_TUD_CDC         1
+#endif
 #define CFG_TUD_MSC             0
 #define CFG_TUD_MIDI            0
 #define CFG_TUD_VENDOR          1

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -50,7 +50,7 @@ tusb_desc_device_t const desc_device =
 #if (PICOPROBE_DEBUG_PROTOCOL == PROTO_OPENOCD_CUSTOM)
     .idProduct          = 0x0004, // Picoprobe
 #else
-    .idProduct          = 0x000e, // CMSIS-DAP adapter
+    .idProduct          = 0x000c, // CMSIS-DAP adapter
 #endif
     .bcdDevice          = 0x0101, // Version 01.01
     .iManufacturer      = 0x01,


### PR DESCRIPTION
I need some debug output from the probe itself, because I'm currently working on it.

And because I have no serial/USB adapter (ok, I could have used another Pico for this...) idea was to use CDC for probe debug output.  Mixing target debug output with probe does not harm TMO, because for regular users it can be switched off completely.

For easier measurements I also included a time stamp for the debug output.