### PR TITLE
Swclk follows adapter speed request

### DIFF
--- a/include/DAP_config.h
+++ b/include/DAP_config.h
@@ -83,7 +83,7 @@ This information includes:
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
 /// Used to initialize the default SWD/JTAG clock frequency.
 /// The command \ref DAP_SWJ_Clock can be used to overwrite this default setting.
-#define DAP_DEFAULT_SWJ_CLOCK   1000000U        ///< Default SWD/JTAG clock frequency in Hz.
+#define DAP_DEFAULT_SWJ_CLOCK   5000000U        ///< Default SWD/JTAG clock frequency in Hz.
 
 /// Maximum Package Size for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the

--- a/src/probe.c
+++ b/src/probe.c
@@ -91,8 +91,7 @@ struct __attribute__((__packed__)) probe_pkt_hdr {
     uint32_t total_packet_length;
 };
 
-void probe_set_swclk_freq(uint freq_khz)
-{
+void probe_set_swclk_freq(uint freq_khz) {
     uint clk_sys_freq_khz = clock_get_hz(clk_sys) / 1000;
 
     if (freq_khz > MAX_SWCLK_KHZ)

--- a/src/sw_dp_pio.c
+++ b/src/sw_dp_pio.c
@@ -32,7 +32,7 @@
 /* Slight hack - we're not bitbanging so we need to set baudrate off the DAP's delay cycles.
  * Ideally we don't want calls to udiv everywhere...
  * Parameter "fast" requests maximum allowed PIO clock */
-#define MAKE_KHZ(fast, delay) (fast ? 100000 : (CPU_CLOCK / 2000) / (delay * DELAY_SLOW_CYCLES + IO_PORT_WRITE_CYCLES))
+#define MAKE_KHZ(fast, delay) ((fast) ? 100000 : (CPU_CLOCK / 2000) / ((delay) * DELAY_SLOW_CYCLES + IO_PORT_WRITE_CYCLES))
 volatile uint32_t cached_delay = 0;
 
 // Generate SWJ Sequence

--- a/src/sw_dp_pio.c
+++ b/src/sw_dp_pio.c
@@ -29,8 +29,9 @@
 #include "DAP.h"
 #include "probe.h"
 
-/* Slight hack - we're not bitbashing so we need to set baudrate off the DAP's delay cycles.
- * Ideally we don't want calls to udiv everywhere... */
+/* Slight hack - we're not bitbanging so we need to set baudrate off the DAP's delay cycles.
+ * Ideally we don't want calls to udiv everywhere...
+ * Parameter "fast" requests maximum allowed PIO clock */
 #define MAKE_KHZ(fast, delay) (fast ? 100000 : (CPU_CLOCK / 2000) / (delay * DELAY_SLOW_CYCLES + IO_PORT_WRITE_CYCLES))
 volatile uint32_t cached_delay = 0;
 

--- a/src/sw_dp_pio.c
+++ b/src/sw_dp_pio.c
@@ -31,7 +31,7 @@
 
 /* Slight hack - we're not bitbashing so we need to set baudrate off the DAP's delay cycles.
  * Ideally we don't want calls to udiv everywhere... */
-#define MAKE_KHZ(x) (CPU_CLOCK / (2000 * ((x) + 1)))
+#define MAKE_KHZ(fast, delay) (fast ? 100000 : (CPU_CLOCK / 2000) / (delay * DELAY_SLOW_CYCLES + IO_PORT_WRITE_CYCLES))
 volatile uint32_t cached_delay = 0;
 
 // Generate SWJ Sequence
@@ -44,7 +44,8 @@ void SWJ_Sequence (uint32_t count, const uint8_t *data) {
   uint32_t n;
 
   if (DAP_Data.clock_delay != cached_delay) {
-    probe_set_swclk_freq(MAKE_KHZ(DAP_Data.clock_delay));
+    picoprobe_info("SWJ_Sequence %lu %d\n", DAP_Data.clock_delay, DAP_Data.fast_clock);
+    probe_set_swclk_freq(MAKE_KHZ(DAP_Data.fast_clock, DAP_Data.clock_delay));
     cached_delay = DAP_Data.clock_delay;
   }
   picoprobe_debug("SWJ sequence count = %d FDB=0x%2x\n", count, data[0]);
@@ -71,7 +72,8 @@ void SWD_Sequence (uint32_t info, const uint8_t *swdo, uint8_t *swdi) {
   uint32_t n;
 
   if (DAP_Data.clock_delay != cached_delay) {
-    probe_set_swclk_freq(MAKE_KHZ(DAP_Data.clock_delay));
+    picoprobe_info("SWD_Sequence\n");
+    probe_set_swclk_freq(MAKE_KHZ(DAP_Data.fast_clock, DAP_Data.clock_delay));
     cached_delay = DAP_Data.clock_delay;
   }
   picoprobe_debug("SWD sequence\n");
@@ -116,7 +118,8 @@ uint8_t SWD_Transfer (uint32_t request, uint32_t *data) {
   uint32_t n;
 
   if (DAP_Data.clock_delay != cached_delay) {
-    probe_set_swclk_freq(MAKE_KHZ(DAP_Data.clock_delay));
+    picoprobe_info("SWD_Transfer\n");
+    probe_set_swclk_freq(MAKE_KHZ(DAP_Data.fast_clock, DAP_Data.clock_delay));
     cached_delay = DAP_Data.clock_delay;
   }
   picoprobe_debug("SWD_transfer\n");


### PR DESCRIPTION
This is the PR belonging to issue #53.

Following fixes:
- SWCLK follows requested adapter speed (before it was ~3x too fast)
- default frequency is now 5MHz (before 1MHz), default is used also in probe_init()
- probe_set_swclk_freq() now has a maximum frequency of 20MHz
- if the user requests a very high adapter freq (and thus DAP_Data.fast_clock becomes set), 20MHz SWCLK is selected