### PR TITLE
Default TUD_OPT_RP2040_USB_DEVICE_UFRAME_FIX=1

### DIFF
--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -74,6 +74,10 @@
 #define CFG_TUD_VENDOR_RX_BUFSIZE 8192
 #define CFG_TUD_VENDOR_TX_BUFSIZE 8192
 
+#ifndef TUD_OPT_RP2040_USB_DEVICE_UFRAME_FIX
+#define TUD_OPT_RP2040_USB_DEVICE_UFRAME_FIX 1
+#endif
+
 #ifdef __cplusplus
  }
 #endif


### PR DESCRIPTION
We may unset this as the default in a future SDK release, but I assume we always want it here for now