### PR TITLE
PIO program improvements

### DIFF
--- a/src/probe.c
+++ b/src/probe.c
@@ -75,21 +75,37 @@ void probe_assert_reset(bool state)
 #endif
 }
 
+typedef enum probe_pio_command {
+    CMD_WRITE = 0,
+    CMD_SKIP,
+    CMD_READ
+} probe_pio_command_t;
+
+static inline uint32_t fmt_probe_command(uint bit_count, bool out_en, probe_pio_command_t cmd) {
+    uint cmd_addr =
+        cmd == CMD_WRITE ? probe.offset + probe_offset_write_cmd :
+        cmd == CMD_SKIP  ? probe.offset + probe_offset_get_next_cmd :
+                           probe.offset + probe_offset_read_cmd;
+    return ((bit_count - 1) & 0xff) | ((uint)out_en << 8) | (cmd_addr << 9);
+}
+
 void probe_write_bits(uint bit_count, uint32_t data_byte) {
     DEBUG_PINS_SET(probe_timing, DBG_PIN_WRITE);
-    pio_sm_put_blocking(pio0, PROBE_SM, bit_count - 1);
+    pio_sm_put_blocking(pio0, PROBE_SM, fmt_probe_command(bit_count, true, CMD_WRITE));
     pio_sm_put_blocking(pio0, PROBE_SM, data_byte);
-    DEBUG_PINS_SET(probe_timing, DBG_PIN_WRITE_WAIT);
     picoprobe_dump("Write %d bits 0x%x\n", bit_count, data_byte);
-    // Wait for pio to push garbage to rx fifo so we know it has finished sending
-    pio_sm_get_blocking(pio0, PROBE_SM);
-    DEBUG_PINS_CLR(probe_timing, DBG_PIN_WRITE_WAIT);
+    // Return immediately so we can cue up the next command whilst this one runs
     DEBUG_PINS_CLR(probe_timing, DBG_PIN_WRITE);
+}
+
+void probe_hiz_clocks(uint bit_count) {
+    pio_sm_put_blocking(pio0, PROBE_SM, fmt_probe_command(bit_count, false, CMD_WRITE));
+    pio_sm_put_blocking(pio0, PROBE_SM, 0);
 }
 
 uint32_t probe_read_bits(uint bit_count) {
     DEBUG_PINS_SET(probe_timing, DBG_PIN_READ);
-    pio_sm_put_blocking(pio0, PROBE_SM, bit_count - 1);
+    pio_sm_put_blocking(pio0, PROBE_SM, fmt_probe_command(bit_count, false, CMD_READ));
     uint32_t data = pio_sm_get_blocking(pio0, PROBE_SM);
     uint32_t data_shifted = data;
     if (bit_count < 32) {
@@ -101,14 +117,20 @@ uint32_t probe_read_bits(uint bit_count) {
     return data_shifted;
 }
 
+static void probe_wait_idle() {
+    pio0->fdebug = 1u << (PIO_FDEBUG_TXSTALL_LSB + PROBE_SM);
+    while (!(pio0->fdebug & (1u << (PIO_FDEBUG_TXSTALL_LSB + PROBE_SM))))
+        ;
+}
+
 void probe_read_mode(void) {
-    pio_sm_exec(pio0, PROBE_SM, pio_encode_jmp(probe.offset + probe_offset_in_posedge));
-    while(pio_sm_get_pc(pio0, PROBE_SM) != probe.offset + probe_offset_in_idle);
+    pio_sm_put_blocking(pio0, PROBE_SM, fmt_probe_command(0, false, CMD_SKIP));
+    probe_wait_idle();
 }
 
 void probe_write_mode(void) {
-    pio_sm_exec(pio0, PROBE_SM, pio_encode_jmp(probe.offset + probe_offset_out_negedge));
-    while(pio_sm_get_pc(pio0, PROBE_SM) != probe.offset + probe_offset_out_idle);
+    pio_sm_put_blocking(pio0, PROBE_SM, fmt_probe_command(0, true, CMD_SKIP));
+    probe_wait_idle();
 }
 
 void probe_init() {
@@ -123,13 +145,11 @@ void probe_init() {
         // Set up divisor
         probe_set_swclk_freq(1000);
 
-        // Enable SM
+        // Jump SM to command dispatch routine, and enable it
+        pio_sm_exec(pio0, PROBE_SM, offset + probe_offset_get_next_cmd);
         pio_sm_set_enabled(pio0, PROBE_SM, 1);
         probe.initted = 1;
     }
-
-    // Jump to write program
-    probe_write_mode();
 }
 
 void probe_deinit(void)

--- a/src/probe.c
+++ b/src/probe.c
@@ -62,8 +62,9 @@ static struct _probe probe;
 void probe_set_swclk_freq(uint freq_khz) {
         uint clk_sys_freq_khz = clock_get_hz(clk_sys) / 1000;
         picoprobe_info("Set swclk freq %dKHz sysclk %dkHz\n", freq_khz, clk_sys_freq_khz);
-        // Worked out with saleae
-        uint32_t divider = clk_sys_freq_khz / freq_khz / 2;
+        uint32_t divider = clk_sys_freq_khz / freq_khz / 4;
+        if (divider == 0)
+            divider = 1;
         pio_sm_set_clkdiv_int_frac(pio0, PROBE_SM, divider, 0);
 }
 

--- a/src/probe.c
+++ b/src/probe.c
@@ -79,14 +79,16 @@ void probe_assert_reset(bool state)
 typedef enum probe_pio_command {
     CMD_WRITE = 0,
     CMD_SKIP,
+    CMD_TURNAROUND,
     CMD_READ
 } probe_pio_command_t;
 
 static inline uint32_t fmt_probe_command(uint bit_count, bool out_en, probe_pio_command_t cmd) {
     uint cmd_addr =
-        cmd == CMD_WRITE ? probe.offset + probe_offset_write_cmd :
-        cmd == CMD_SKIP  ? probe.offset + probe_offset_get_next_cmd :
-                           probe.offset + probe_offset_read_cmd;
+        cmd == CMD_WRITE      ? probe.offset + probe_offset_write_cmd :
+        cmd == CMD_SKIP       ? probe.offset + probe_offset_get_next_cmd :
+        cmd == CMD_TURNAROUND ? probe.offset + probe_offset_turnaround_cmd :
+                                probe.offset + probe_offset_read_cmd;
     return ((bit_count - 1) & 0xff) | ((uint)out_en << 8) | (cmd_addr << 9);
 }
 
@@ -100,7 +102,7 @@ void probe_write_bits(uint bit_count, uint32_t data_byte) {
 }
 
 void probe_hiz_clocks(uint bit_count) {
-    pio_sm_put_blocking(pio0, PROBE_SM, fmt_probe_command(bit_count, false, CMD_WRITE));
+    pio_sm_put_blocking(pio0, PROBE_SM, fmt_probe_command(bit_count, false, CMD_TURNAROUND));
     pio_sm_put_blocking(pio0, PROBE_SM, 0);
 }
 

--- a/src/probe.h
+++ b/src/probe.h
@@ -35,8 +35,11 @@
 #endif
 
 void probe_set_swclk_freq(uint freq_khz);
+
+// Bit counts in the range 1..256
 void probe_write_bits(uint bit_count, uint32_t data_byte);
 uint32_t probe_read_bits(uint bit_count);
+void probe_hiz_clocks(uint bit_count);
 
 void probe_read_mode(void);
 void probe_write_mode(void);

--- a/src/probe.pio
+++ b/src/probe.pio
@@ -39,6 +39,8 @@
 // garbage on writes allows the interface code to return early after pushing a
 // write command, as there is no need in general to poll for a command's
 // completion as long as all commands are executed in order.)
+//
+// The SWCLK period is 4 PIO SM execution cycles.
 
 .program probe
 .side_set 1 opt
@@ -46,22 +48,23 @@
 public write_cmd:
     pull
 write_bitloop:
-    out pins, 1             side 0x0   ; Data is output by host on negedge
-    jmp x-- write_bitloop   side 0x1   ; ...and captured by target on posedge
-                                       ; Fall through to next command
+    out pins, 1             [1]  side 0x0   ; Data is output by host on negedge
+    jmp x-- write_bitloop   [1]  side 0x1   ; ...and captured by target on posedge
+                                            ; Fall through to next command
 .wrap_target
 public get_next_cmd:
-    pull                    side 0x0   ; SWCLK is initially low
-    out x, 8                           ; Get bit count
-    out pindirs, 1                     ; Set SWDIO direction
-    out pc, 5                          ; Go to command routine
+    pull                         side 0x0   ; SWCLK is initially low
+    out x, 8                                ; Get bit count
+    out pindirs, 1                          ; Set SWDIO direction
+    out pc, 5                               ; Go to command routine
 
-public read_cmd:
 read_bitloop:
-    in pins, 1              side 0x1   ; Data is captured by host on posedge
-    jmp x-- read_bitloop    side 0x0
+    nop                                     ; Additional delay on taken loop branch
+public read_cmd:
+    in pins, 1              [1]  side 0x1   ; Data is captured by host on posedge
+    jmp x-- read_bitloop         side 0x0
     push
-.wrap                                  ; Wrap to next command
+.wrap                                       ; Wrap to next command
 
 
 ; Implement probe_gpio_init() and probe_sm_init() methods here - set pins, offsets, sidesets etc

--- a/src/probe.pio
+++ b/src/probe.pio
@@ -46,6 +46,7 @@
 .side_set 1 opt
 
 public write_cmd:
+public turnaround_cmd:                      ; Alias of write, used for probe_oen.pio
     pull
 write_bitloop:
     out pins, 1             [1]  side 0x0   ; Data is output by host on negedge

--- a/src/probe.pio
+++ b/src/probe.pio
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2021-2023 Raspberry Pi (Trading) Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,32 +23,46 @@
  *
  */
 
+// Every TX FIFO entry is either a command, or up to 32 bits of data.
+// Command format:
+//
+// | 13:9 |  8  |  7:0  |
+// | Cmd  | Dir | Count |
+//
+// Count is the number of bits to be transferred by this command, minus 1.
+// Dir is the output enable for the SWDIO pin.
+// Cmd is the address of the write_cmd, read_cmd or get_next_cmd label.
+//
+// write_cmd expects a FIFO data entry, but read_cmd does not.
+//
+// read_cmd pushes data to the FIFO, but write_cmd does not. (The lack of RX
+// garbage on writes allows the interface code to return early after pushing a
+// write command, as there is no need in general to poll for a command's
+// completion as long as all commands are executed in order.)
+
 .program probe
 .side_set 1 opt
 
-public out_negedge:
-    set pindirs, 1 side 0x0 ; Init OE clock 0
-public out_idle:
-    pull           ; Pull number of bits to shift -1 from tx fifo and put into output shift register
-    mov x, osr     ; mov bits to shift -1 from output shift register into x
-    pull           ; Pull data to shift out
-out_negedge_bitloop:
-    out pins, 1                  side 0x0 ; clock data out on falling edge
-    jmp  x-- out_negedge_bitloop side 0x1 ; data is present for posedge
-    set pins, 1                  side 0x0 ; Drive data high (idle bus state)
-    push                                 ; Push to rx fifo just so processor knows when done
-    jmp out_negedge                      ; Wait for next transaction
+public write_cmd:
+    pull
+write_bitloop:
+    out pins, 1             side 0x0   ; Data is output by host on negedge
+    jmp x-- write_bitloop   side 0x1   ; ...and captured by target on posedge
+                                       ; Fall through to next command
+.wrap_target
+public get_next_cmd:
+    pull                    side 0x0   ; SWCLK is initially low
+    out x, 8                           ; Get bit count
+    out pindirs, 1                     ; Set SWDIO direction
+    out pc, 5                          ; Go to command routine
 
-public in_posedge:
-    set pindirs, 0 side 0x0 ; INIT IE clock 0
-public in_idle:
-    pull                   ; Pull number of bits to shift -1 from tx fifo and put into output shift register
-    mov x, osr             ; mov bits to shift -1 from output shift register into x into x
-in_posedge_bitloop:
-    in pins, 1                        side 0x1 ; Generate posedge and read data
-    jmp x-- in_posedge_bitloop        side 0x0 ;
-    push                                      ; Push to rx fifo when done
-    jmp in_posedge                            ; Jump back to start
+public read_cmd:
+read_bitloop:
+    in pins, 1              side 0x1   ; Data is captured by host on posedge
+    jmp x-- read_bitloop    side 0x0
+    push
+.wrap                                  ; Wrap to next command
+
 
 ; Implement probe_gpio_init() and probe_sm_init() methods here - set pins, offsets, sidesets etc
 % c-sdk {

--- a/src/probe_oen.pio
+++ b/src/probe_oen.pio
@@ -1,39 +1,48 @@
 ; Output-enable active-low variant of the SWD probe
 
+; This program is very similar to the one in probe.pio. The only difference is
+; that here write_cmd and turnaround_cmd are split into two separate routines,
+; whose difference is OEn being high/low.
+
+; SWDIO_OEn is pin 0, SWCLK pin 1, SWDIO (out) pin 2, SWDI (in) pin 3.
+; Pin 0 and 1 are sideset pins
+
 .program probe
 .side_set 2 opt
 
-; SWDIO_OEN is pin 0, SWCLK pin 1, SWDIO (out) pin 2, SWDI (in) pin 3.
-; Pin 0 and 1 are sideset pins
-public out_negedge:
-  set pindirs, 0x1 side 0x0    ; OE_N 0, data high, clock 0
-public out_idle:
-  pull                         ; pull nbits - 1
-  mov x, osr
-  pull                         ; pull data
-public out_negedge_bitloop:
-  out pins, 1                  side 0x0
-  jmp x-- out_negedge_bitloop  side 0x2  ; OE_N 0, clock high
-  set pins, 1                  side 0x0  ; drive data high (idle bus state)
-  push                         ; Push to rx fifo just so processor knows when done
-  jmp out_negedge              ; Wait for next transaction
+public turnaround_cmd:
+    pull
+turnaround_bitloop:
+    nop                         [1]  side 0x1
+    jmp x-- turnaround_bitloop  [1]  side 0x3
+    jmp get_next_cmd
 
-public in_posedge:
-  set pindirs, 0x0            side 0x1 ; OE_N 1, data high, clock 0
-public in_idle:
-  pull
-  mov x, osr
-in_posedge_bitloop:
-  in pins, 1                  side 0x1 ; OE_N 1, clock 0
-  jmp x-- in_posedge_bitloop  side 0x3 ; OE_N 1, clock 1
-  push
-  jmp in_posedge
+public write_cmd:
+    pull
+write_bitloop:
+    out pins, 1                 [1]  side 0x0   ; Data is output by host on negedge
+    jmp x-- write_bitloop       [1]  side 0x2   ; ...and captured by target on posedge
+                                                ; Fall through to next command
+.wrap_target
+public get_next_cmd:
+    pull                             side 0x1   ; SWCLK initially low, OEn disabled
+    out x, 8                                    ; Get bit count
+    out pindirs, 1                              ; Set SWDIO direction
+    out pc, 5                                   ; Go to command routine
+
+read_bitloop:
+    nop                                         ; Additional delay on taken loop branch
+public read_cmd:
+    in pins, 1                  [1]  side 0x3   ; Data is captured by host on posedge
+    jmp x-- read_bitloop             side 0x1
+    push
+.wrap                                           ; Wrap to next command
 
 
 ; Implement probe_gpio_init() and probe_sm_init() methods here - set pins, offsets, sidesets etc
 % c-sdk {
 
-void probe_gpio_init()
+static inline void probe_gpio_init()
 {
 #if defined(PROBE_PIN_RESET)
     // Target reset pin: pull up, input to emulate open drain pin
@@ -51,10 +60,10 @@ void probe_gpio_init()
     gpio_pull_up(PROBE_PIN_SWDIOEN);
 }
 
-void probe_sm_init(pio_sm_config* sm_config) {
+static inline void probe_sm_init(pio_sm_config* sm_config) {
 
     // Set SWDIOEN and SWCLK as sideset pins
-    sm_config_set_sideset_pins(&sm_config, PROBE_PIN_SWDIOEN);
+    sm_config_set_sideset_pins(sm_config, PROBE_PIN_SWDIOEN);
 
     // Set SWDIO offset
     sm_config_set_out_pins(sm_config, PROBE_PIN_SWDIO, 1);


### PR DESCRIPTION
This seems to get me ~10% more write throughput at 5 MHz. The two changes are:

* Rewrite the PIO program so that it accepts read/write commands in the FIFO alongside bit counts, and does not return RX garbage on write commands. This removes unnecessary tight coupling between PIO and M0+.
* Add a delay cycle to each SWCLK half-period, so that the PIO SM can be clocked twice as fast for a given SWCLK frequency. This reduces dead time between commands.

With this change the maximum possible SWCLK frequency is reduced to clk_sys/4, i.e. 32.5 MHz with a 125 MHz system clock, but this still seems to be well beyond the point of diminishing returns for an FS USB probe.