### PR TITLE
Don't call probe_read_mode() in deinit() without matching prior init(), fixes #88

### DIFF
--- a/src/probe.c
+++ b/src/probe.c
@@ -157,8 +157,8 @@ void probe_init() {
 
 void probe_deinit(void)
 {
-  probe_read_mode();
   if (probe.initted) {
+    probe_read_mode();
     pio_sm_set_enabled(pio0, PROBE_SM, 0);
     pio_remove_program(pio0, &probe_program, probe.offset);
     probe.initted = 0;


### PR DESCRIPTION
See #88. This function is now implemented by writing a command to an SM FIFO and then waiting for it to complete. If the SM is not running then this will block forever.

I think the original intention was to always make sure the pin is left tristated, but I think this `if` block is skipped in exactly two cases:

* `probe_init()` has never been called
* `probe_deinit()` has already been called at least once since the last `probe_init()`

And in both cases the pin is already tristated.