### PR TITLE
Support resetting Picoprobe board using USB RESET interface (RP2040)

### DIFF
--- a/include/board_pico_config.h
+++ b/include/board_pico_config.h
@@ -49,4 +49,7 @@
 
 #define PROBE_PRODUCT_STRING "Picoprobe (CMSIS-DAP)"
 
+// Host Reset Config
+#define PICOPROBE_RESET_CAPABLE 1
+
 #endif

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -26,6 +26,8 @@
 #ifndef _TUSB_CONFIG_H_
 #define _TUSB_CONFIG_H_
 
+#include "picoprobe_config.h"
+
 #ifdef __cplusplus
  extern "C" {
 #endif
@@ -66,7 +68,12 @@
 #define CFG_TUD_CDC             1
 #define CFG_TUD_MSC             0
 #define CFG_TUD_MIDI            0
+
+#if PICOPROBE_RESET_CAPABLE
+#define CFG_TUD_VENDOR          2
+#else
 #define CFG_TUD_VENDOR          1
+#endif
 
 /*
  * TX bufsize (actually UART RX) is oversized because the Windows CDC-ACM

--- a/src/usb_reset_interface.h
+++ b/src/usb_reset_interface.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PICO_USB_RESET_INTERFACE_H
+#define _PICO_USB_RESET_INTERFACE_H
+
+/** \file usb_reset_interface.h
+ *  \defgroup pico_usb_reset_interface pico_usb_reset_interface
+ *
+ * Definition for the reset interface that may be exposed by the pico_stdio_usb library
+ */
+
+// VENDOR sub-class for the reset interface
+#define RESET_INTERFACE_SUBCLASS 0x00
+// VENDOR protocol for the reset interface
+#define RESET_INTERFACE_PROTOCOL 0x01
+
+// CONTROL requests:
+
+// reset to BOOTSEL
+#define RESET_REQUEST_BOOTSEL 0x01
+// regular flash boot
+#define RESET_REQUEST_FLASH 0x02
+
+#endif


### PR DESCRIPTION
We have a use-case involving reusing RP2040 supervisor as an SWD debug interface during initial testing. This implements standard Pico SDK C++ usb reset endpoints to interoperate with appropriately patched picotool. The patch enables this functionality by default, but it can be disabled with a config switch to avoid accidentally rebooting the incorrect RP2040 device. 

https://github.com/raspberrypi/picotool/compare/master...FarProbe:picotool:master

